### PR TITLE
NEW Create js-prs-issue.yml

### DIFF
--- a/.github/workflows/js-prs-issue.yml
+++ b/.github/workflows/js-prs-issue.yml
@@ -1,0 +1,54 @@
+name: JS PRs issue
+
+on:
+  # At 7:00am UTC on the 15th of February, May, August, and November
+  schedule:
+    - cron: '0 7 15 2,5,8,11 *'
+  workflow_dispatch:
+
+jobs:
+  js-prs-issue:
+    name: JS PRs issue
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: JS PRs issue
+        uses: silverstripe/gha-issue@v1
+        with:
+          title: JS pull-requests
+          description: |
+            This is an automatically created issue used to list automatically created
+            javascript pull requests every 3 months.\n
+            \n
+            It was created by the `.github/workflows/js-prs-issue.yml` workflow in the [silverstripe/.github](https://github.com/silverstripe/.github/) repository.\n
+            \n
+            ### Triage instructions (Silverstripe Ltd CMS Squad)\n
+            1. Put on the following labels:\n
+               - `type/enhancement`\n
+               - `impact/low`\n
+               - `affects/v5`\n
+            2. Move this issue to the "Ready" column on our internal zenhub board\n
+            \n
+            ### Update JS pull-requests:\n
+            - [List of update JS pull-requests](https://emtek.net.nz/rhino/tables?t=open-prs&filters={%22title%22%3A%22DEP%20Update%20JS%20dependencies%22})\n
+            - Merge these PRs if there are no merge-conflicts\n
+            - If there are merge conflicts in some PRs, then close those PRs and run the steps below in the "Manually creating update JS pull-requests" section below for those relevant modules\n
+            \n
+            ### Manually creating update JS pull-requests:\n
+            1. Ensure you have the default branch checked out for the module you are updating e.g. `5`\n
+            2. Ensure `silverstripe/silverstripe-admin` is installed in a *sibling* directory\n
+            3. In the `silverstripe-admin` directory, ensure the default branch is checked out e.g. `2`\n
+            4. In the `silverstripe-admin` directory, run `yarn install`\n
+            5. In the directory of module you're updating JS for, run `yarn upgrade`\n
+            6. Run `yarn build` in the directory of module you're updating JS for\n
+            7. Git commit, push the changes and create a pull-request\n
+            8. List the pull-request(s) on this issue\n
+            9. Move this issue to the peer review column on the CMS Squad internal zenhub board\n
+            \n
+            ### Dependabot pull-requests:\n
+            - [List of dependabot pull-requests](https://emtek.net.nz/rhino/tables?t=open-prs&filters={%22author%22%3A%22dependabot%22})\n
+            - Most of these should be automatically closed if the "Update JS pull-requests" above are merged\n
+            - You can make a judgement call as to whether to merge any easy ones that are left\n
+
+

--- a/.github/workflows/translation-issue.yml
+++ b/.github/workflows/translation-issue.yml
@@ -20,7 +20,7 @@ jobs:
           description: |
             This is an automatically created issue used to run translations every 3 months.\n
             \n
-            It was created by the `translation-issue.yml` workflow in the `silverstripe/.github` repository.\n
+            It was created by the `.github/workflows/translation-issue.yml` workflow in the [silverstripe/.github](https://github.com/silverstripe/.github/) repository.\n
             \n
             ### Triage instructions (Silverstripe Ltd CMS Squad)\n
             1. Put on the following labels:\n


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/52

Example output https://github.com/emteknetnz/silverstripe-campaign-admin/issues/10

I've implemented this to just look at a filtered view of the rhino 'open-prs' view because it is WAY more less work than creating something to do API's requests to read all open pull-requests of all supported modules, and only a very mild decrease in usability. Also if we did the API reading in the github-action then we'd be duplicating work already done in rhino which would be pretty wasteful.
