### PR TITLE
MNT Update js-prs-issue workflow to include dependabot alerts

### DIFF
--- a/.github/workflows/js-prs-issue.yml
+++ b/.github/workflows/js-prs-issue.yml
@@ -14,8 +14,64 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
+      - name: Get Alerts List
+        id: get-alerts-list
+        run: |
+          ALERTS_LIST=''
+
+          # Get list of supported modules
+          # Assumes CMS 5 is the most recent stable version
+          curl -s -o __modules.json https://raw.githubusercontent.com/silverstripe/supported-modules/5/modules.json
+          # If we can't parse the JSON at all, $MODULES will be an empty string and that means we couldn't fetch the file.
+          MODULES=$(jq -e '.' __modules.json) || true
+          if [[ $MODULES == "" ]]; then
+            # If there is some error getting the file, the error will be in the __modules.json file - importantly, not in JSON format.
+            echo "Cannot parse supported-modules JSON. Aborting. The content we tried to parse was:"
+            cat __modules.json
+            # Instead of exiting, output an error instead of the dependabot alert list.
+            # We don't have any reporting indicating if this workflow fails, so this is a good way to track that.
+            ALERTS_LIST='Failed to parse supported-modules JSON. Please check the GitHub action log.'
+          fi
+
+          # Create a list of markdown links for supported module dependabot stuff
+          ALERTS_LIST=$(php -r '
+            $json = json_decode(file_get_contents("__modules.json"), true);
+            foreach ($json as $module) {
+              # Skip non-github modules, if any listed
+              if (!$module["github"]) {
+                continue;
+              }
+              $githubRef = $module["github"];
+              $branch = end($module["branches"]);
+              $packageJsonURL = "https://raw.githubusercontent.com/$githubRef/$branch/package.json";
+              $headers = get_headers($packageJsonURL);
+              # $headers[0] includes the response code in a format like: "HTTP/1.1 404 Not Found"
+              $response = $headers[0];
+              # Skip modules which do not have a package.json file
+              if (strpos($response, "404") !== false) {
+                continue;
+              }
+              # If we have something other than 404 (above) or 200, output an error string for the list
+              # and move on.
+              if (strpos($response, "200") === false) {
+                echo "- $githubRef: Unable to check package.json, response was $response.\\n";
+                continue;
+              }
+
+              # If we get here, we have a package.json file so we should add a dependabot alerts URL to the list
+              echo "- [$githubRef](https://github.com/$githubRef/security/dependabot)\\n";
+            }
+          ')
+          
+          echo 'ALERTS_LIST is:'
+          echo $ALERTS_LIST
+          echo "alerts_list=$ALERTS_LIST" >> $GITHUB_OUTPUT
+
+        
       - name: JS PRs issue
         uses: silverstripe/gha-issue@v1
+        env:
+          ALERTS_LIST: ${{ steps.get-alerts-list.outputs.alerts_list }}
         with:
           title: JS pull-requests
           description: |
@@ -54,5 +110,15 @@ jobs:
             - [List of dependabot pull-requests](https://emtek.net.nz/rhino/tables?t=open-prs&filters={%22author%22%3A%22dependabot%22})\n
             - Most of these should be automatically closed if the "Update JS pull-requests" above are merged\n
             - You can make a judgement call as to whether to merge any easy ones that are left\n
+            \n
+            ### Dependabot alerts:\n
+            After all of the above have been completed and resolved, check for any outstanding dependabot alerts:\n
+            ${{ env.ALERTS_LIST }}
 
-
+      - name: Delete temporary files
+        shell: bash
+        if: always()
+        run: |
+          if [[ -f __modules.json ]]; then
+            rm __modules.json
+          fi


### PR DESCRIPTION
Adds a new section to the js PRs issue for checking dependabot alerts.
Only includes URLs for supported repos in the latest stable major release line, and only if they have a package.json file.

[successfully ran on my fork](https://github.com/GuySartorelli/silverstripe.github/actions/runs/6399169150/job/17370723428)
[example issue created by the workflow](https://github.com/GuySartorelli/silverstripe.github/issues/7)

## Issue
- https://github.com/silverstripeltd/product-issues/issues/812