### PR TITLE
DOC Add file for core committers to indicate they read policies

### DIFF
--- a/maintainers/core-committers.md
+++ b/maintainers/core-committers.md
@@ -1,0 +1,49 @@
+# Core Committers
+
+The following documentation must be read annually.
+
+- [Maintainer guidelines](https://docs.silverstripe.org/en/project_governance/maintainer_guidelines/)
+- [Secure coding](https://docs.silverstripe.org/en/developer_guides/security/secure_coding/)
+- [Definition of public API](https://docs.silverstripe.org/en/5/project_governance/public_api/)
+
+Please read the documentation listed above, and then update the date next to your name in the table below.
+
+Core Committers who don't update this table within a year will have their access revoked until they update it.
+
+|Core Committer|Date last read|
+|---|---|
+|[Aaron Carlino](https://github.com/unclecheese/)||
+|[Garion Herman](https://github.com/cheddam)||
+|[Guy Sartorelli](https://github.com/GuySartorelli)||
+|[Ingo Schommer](https://github.com/chillu)||
+|[Loz Calver](https://github.com/kinglozzer)||
+|[Matt Peel](https://github.com/madmatt)||
+|[Maxime Rainville](https://github.com/maxime-rainville)||
+|[Michal Kleiner](https://github.com/michalkleiner)||
+|[Sam Minnée](https://github.com/sminnee)||
+|[Steve Boyd](https://github.com/emteknetnz)||
+|[Will Rossiter](https://github.com/wilr/)||
+
+## Security triage
+
+Core Committers are allowed access to the private GitHub organisation where security issues are raised and discussed, and where security patches are held until they're ready for release.
+
+- [Managing security issues](https://docs.silverstripe.org/en/contributing/managing_security_issues/)
+
+If you want access to the security please read the documentation listed above, update the date next to your name in the table below, and ensure "wants access" has a "yes".
+
+Core Committers who don't update this table within a year will have their access revoked until they update it.
+
+|Core Committer|Wants access|Date last read|
+|---|---|---|
+|[Aaron Carlino](https://github.com/unclecheese/)|||
+|[Garion Herman](https://github.com/cheddam)|||
+|[Guy Sartorelli](https://github.com/GuySartorelli)|||
+|[Ingo Schommer](https://github.com/chillu)|||
+|[Loz Calver](https://github.com/kinglozzer)|||
+|[Matt Peel](https://github.com/madmatt)|||
+|[Maxime Rainville](https://github.com/maxime-rainville)|||
+|[Michal Kleiner](https://github.com/michalkleiner)|||
+|[Sam Minnée](https://github.com/sminnee)|||
+|[Steve Boyd](https://github.com/emteknetnz)|||
+|[Will Rossiter](https://github.com/wilr/)|||


### PR DESCRIPTION
@silverstripe/core-team The links to documentation here replace the policy document that had been written - the approach is to keep the status quo, while having a way to annually review access to please auditors.

## Issue
- https://github.com/silverstripe/.github/issues/263